### PR TITLE
Added 'address' to the vote options

### DIFF
--- a/src/sendVote.ts
+++ b/src/sendVote.ts
@@ -54,7 +54,7 @@ export function sendVote(host: string, port = 8192, options: SendVoteOptions): P
 				const payload: Record<string, string | number> = {
 					serviceName: options.serviceName ?? 'minecraft-server-util (https://github.com/PassTheMayo/minecraft-server-util)',
 					username: options.username,
-					address: host + ':' + port,
+					address: options.address ?? host + ':' + port,
 					timestamp: options.timestamp ?? Date.now(),
 					challenge: challengeToken
 				};

--- a/src/types/SendVoteOptions.ts
+++ b/src/types/SendVoteOptions.ts
@@ -1,6 +1,7 @@
 export interface SendVoteOptions {
     token: string,
     username: string,
+    address?: string;
     serviceName?: string,
     uuid?: string,
     timestamp?: number,


### PR DESCRIPTION
Made it possible to pass any IP address along with a Votifier v2 vote, which in most cases would probably be the voter's IP address. It will still use the host:port combination as a fallback when no address is given.

Their docs state the IP address should be the voter's address (though it's stated in the v1 docs, I'm certain it applies to v2 as well) https://github.com/NuVotifier/NuVotifier/wiki/Technical-QA#protocol-v2 or see their own JS implementation: https://github.com/NuVotifier/votifier2-js