### PR TITLE
Added function to send legacy Votifier (v1) votes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './queryBasic';
 export * from './queryFull';
 export * from './scanLAN';
 export * from './sendVote';
+export * from './sendLegacyVote';
 export * from './structure/RCON';
 export * from './util/parseAddress';
 
@@ -21,4 +22,5 @@ export * from './types/JavaStatusOptions';
 export * from './types/JavaStatusResponse';
 export * from './types/QueryOptions';
 export * from './types/SendVoteOptions';
+export * from './types/SendLegacyVoteOptions';
 export * from './types/SRVRecord';

--- a/src/sendLegacyVote.ts
+++ b/src/sendLegacyVote.ts
@@ -1,0 +1,92 @@
+import assert from 'assert';
+import crypto from 'crypto';
+import TCPClient from './structure/TCPClient';
+import {SendLegacyVoteOptions} from './types/SendLegacyVoteOptions';
+
+const wordwrap = (str: string, size: number): string => str.replace(
+	new RegExp(`(?![^\\n]{1,${size}}$)([^\\n]{1,${size}})\\s`, 'g'), '$1\n'
+);
+
+export function sendLegacyVote(host: string, port = 8192, options: SendLegacyVoteOptions): Promise<void> {
+	host = host.trim();
+
+	assert(typeof host === 'string', `Expected 'host' to be a 'string', got '${typeof host}'`);
+	assert(host.length > 1, `Expected 'host' to have a length greater than 0, got ${host.length}`);
+	assert(typeof port === 'number', `Expected 'port' to be a 'number', got '${typeof port}'`);
+	assert(Number.isInteger(port), `Expected 'port' to be an integer, got '${port}'`);
+	assert(port >= 0, `Expected 'port' to be greater than or equal to 0, got '${port}'`);
+	assert(port <= 65535, `Expected 'port' to be less than or equal to 65535, got '${port}'`);
+	assert(typeof options === 'object', `Expected 'options' to be an 'object', got '${typeof options}'`);
+	assert(typeof options.username === 'string', `Expected 'options.username' to be an 'string', got '${typeof options.username}'`);
+	assert(options.username.length > 1, `Expected 'options.username' to have a length greater than 0, got ${options.username.length}`);
+	assert(typeof options.key === 'string', `Expected 'options.key' to be an 'string', got '${typeof options.key}'`);
+	assert(options.key.length > 1, `Expected 'options.key' to have a length greater than 0, got ${options.key.length}`);
+
+	return new Promise(async (resolve, reject) => {
+		let socket: TCPClient | undefined = undefined;
+
+		const timeout = setTimeout(() => {
+			socket?.close();
+
+			reject(new Error('Timed out while retrieving server status'));
+		}, options?.timeout ?? 1000 * 5);
+
+		try {
+			socket = new TCPClient();
+
+			await socket.connect({ host, port, timeout: options?.timeout ?? 1000 * 5 });
+
+			// Handshake packet
+			// https://github.com/NuVotifier/NuVotifier/wiki/Technical-QA#handshake
+			{
+				const version = await socket.readStringUntil(0x0A);
+				const split = version.split(' ');
+
+				if (split[0] !== 'VOTIFIER') throw new Error('Not connected to a Votifier server. Expected VOTIFIER in handshake, received: ' + version);
+			}
+
+			// Send vote packet
+			// https://github.com/NuVotifier/NuVotifier/wiki/Technical-QA#protocol-v1
+			{
+				// Format the key
+				options.key = options.key.replace(/ /g, '+');
+				options.key = wordwrap(options.key, 65);
+
+				const timestamp = options.timestamp ?? Date.now();
+				const address = options.address ?? host + ':' + port;
+
+				// Create public key key and vote strings
+				const publicKey = `-----BEGIN PUBLIC KEY-----\n${options.key}\n-----END PUBLIC KEY-----\n`;
+				const vote = `VOTE\n${options.serviceName}\n${options.username}\n${address}\n${timestamp}\n`;
+
+				// Encrypt the vote
+				const encryptedPayload = crypto.publicEncrypt(
+					{
+						key: publicKey,
+						padding: crypto.constants.RSA_PKCS1_PADDING,
+					},
+					Buffer.from(vote)
+				);
+
+				// Send vote to server
+				socket.writeBytes(encryptedPayload);
+				await socket.flush(false);
+			}
+
+			// Close connection
+			{
+				clearTimeout(timeout);
+
+				socket.close();
+
+				resolve();
+			}
+		} catch (e) {
+			clearTimeout(timeout);
+
+			socket?.close();
+
+			reject(e);
+		}
+	});
+}

--- a/src/sendVote.ts
+++ b/src/sendVote.ts
@@ -43,6 +43,7 @@ export function sendVote(host: string, port = 8192, options: SendVoteOptions): P
 				const version = await socket.readStringUntil(0x0A);
 				const split = version.split(' ');
 
+				if (split[0] !== 'VOTIFIER') throw new Error('Not connected to a Votifier server. Expected VOTIFIER in handshake, received: ' + version);
 				if (split[1] !== '2') throw new Error('Unsupported Votifier version: ' + split[1]);
 
 				challengeToken = split[2];

--- a/src/types/SendLegacyVoteOptions.ts
+++ b/src/types/SendLegacyVoteOptions.ts
@@ -1,0 +1,8 @@
+export interface SendLegacyVoteOptions {
+    key: string,
+    username: string,
+    address?: string;
+    serviceName?: string,
+    timestamp?: number,
+    timeout?: number
+}


### PR DESCRIPTION
Legacy votes are the Votifier protocol 1 (v1) votes using RSA. NuVotifier marked v1/classic/legacy votes as deprecated, but as of now the functionality is still available - and I don't see them actually removing v1 votes completely anytime soon.

Also added an additional check to sendVote handshake, to make sure a connection was made with a Votifier server.