### PR TITLE
Fix EventEmitter memory leak in TCPClient

### DIFF
--- a/src/structure/TCPClient.ts
+++ b/src/structure/TCPClient.ts
@@ -504,8 +504,8 @@ class TCPClient extends EventEmitter {
 				reject(new Error('Socket closed unexpectedly while waiting for data'));
 			};
 
-			this.on('data', () => dataHandler());
-			this.on('close', () => closeHandler());
+			this.on('data', dataHandler);
+			this.on('close', closeHandler);
 		});
 	}
 }


### PR DESCRIPTION
Due to wrapping event handlers in arrow functions, `data` and `close` event handlers never get cleaned up when waiting for data on a TCP connection.