### PR TITLE
Add workaround for Minecraft bugs MC-221987 and MC-231035

### DIFF
--- a/src/queryFull.ts
+++ b/src/queryFull.ts
@@ -4,6 +4,18 @@ import UDPClient from './structure/UDPClient';
 import { QueryOptions } from './types/QueryOptions';
 import { resolveSRV } from './util/srvRecord';
 
+const validKeys: Buffer[] = [
+	'gametype',
+	'game_id',
+	'version',
+	'plugins',
+	'map',
+	'numplayers',
+	'maxplayers',
+	'hostport',
+	'hostip'
+].map(s => Buffer.from(s, 'utf-8'));
+
 export interface FullQueryResponse {
 	motd: {
 		raw: string,
@@ -123,7 +135,7 @@ export function queryFull(host: string, port = 25565, options?: QueryOptions): P
 
 					if (key.length < 1) break;
 
-					const value = await socket.readStringNT();
+					const value = await socket.readStringNTFollowedBy(validKeys);
 
 					data[key] = value;
 				}

--- a/src/queryFull.ts
+++ b/src/queryFull.ts
@@ -14,7 +14,7 @@ const validKeys: Buffer[] = [
 	'maxplayers',
 	'hostport',
 	'hostip'
-].map(s => Buffer.from(s, 'utf-8'));
+].map(s => Buffer.from(s, 'ascii'));
 
 export interface FullQueryResponse {
 	motd: {

--- a/src/queryFull.ts
+++ b/src/queryFull.ts
@@ -135,7 +135,12 @@ export function queryFull(host: string, port = 25565, options?: QueryOptions): P
 
 					if (key.length < 1) break;
 
-					const value = await socket.readStringNTFollowedBy(validKeys);
+					let value;
+					if(key === 'hostname') {
+						value = await socket.readStringNTFollowedBy(validKeys);
+					} else  {
+						value = await socket.readStringNT();
+					}
 
 					data[key] = value;
 				}

--- a/src/queryFull.ts
+++ b/src/queryFull.ts
@@ -136,9 +136,9 @@ export function queryFull(host: string, port = 25565, options?: QueryOptions): P
 					if (key.length < 1) break;
 
 					let value;
-					if(key === 'hostname') {
+					if (key === 'hostname') {
 						value = await socket.readStringNTFollowedBy(validKeys);
-					} else  {
+					} else {
 						value = await socket.readStringNT();
 					}
 

--- a/src/queryFull.ts
+++ b/src/queryFull.ts
@@ -162,7 +162,7 @@ export function queryFull(host: string, port = 25565, options?: QueryOptions): P
 				socket.close();
 
 				if (socket.hasRemainingData()) {
-					reject(new Error('Server sent more data than expected'));
+					throw new Error('Server sent more data than expected');
 				}
 
 				clearTimeout(timeout);

--- a/src/queryFull.ts
+++ b/src/queryFull.ts
@@ -161,6 +161,10 @@ export function queryFull(host: string, port = 25565, options?: QueryOptions): P
 
 				socket.close();
 
+				if (socket.hasRemainingData()) {
+					reject(new Error('Server sent more data than expected'));
+				}
+
 				clearTimeout(timeout);
 
 				resolve({

--- a/src/structure/UDPClient.ts
+++ b/src/structure/UDPClient.ts
@@ -402,7 +402,7 @@ class UDPClient extends EventEmitter {
 		// eslint-disable-next-line no-constant-condition
 		while (true) {
 			const value = await this.readByte();
-			if(value === 0x00 && await this.checkUpcomingData(suffixes)) {
+			if (value === 0x00 && await this.checkUpcomingData(suffixes)) {
 				break;
 			}
 			buf = Buffer.concat([buf, Buffer.from([value])]);
@@ -410,7 +410,7 @@ class UDPClient extends EventEmitter {
 		return Array.from(buf).map((point) => String.fromCodePoint(point)).join('');
 	}
 
-	async checkUpcomingData(suffixes: Buffer[]): Promise<Buffer|null> {
+	async checkUpcomingData(suffixes: Buffer[]): Promise<Buffer | null> {
 		let i = 0;
 		while (suffixes.length) {
 			await this.ensureBufferedData(i + 1);

--- a/src/structure/UDPClient.ts
+++ b/src/structure/UDPClient.ts
@@ -496,6 +496,10 @@ class UDPClient extends EventEmitter {
 			this.socket.on('error', (error) => errorHandler(error));
 		});
 	}
+
+	hasRemainingData(): boolean {
+		return this.data.byteLength > 0;
+	}
 }
 
 export default UDPClient;


### PR DESCRIPTION
This pull request aims to work around issues caused by malformed MOTD strings in Minecraft query responses.
https://bugs.mojang.com/projects/MC/issues/MC-221987
https://bugs.mojang.com/projects/MC/issues/MC-231035

MOTDs in query responses can, in various cases, contain null bytes. This is quite unfortunate, as all strings in query responses are null terminated. 
Some Unicode characters, including a number of Chinese and Korean characters, will simply be "encoded" to null bytes. Whenever a code point is larger than one byte, Minecraft will only add the last byte to the encoded string.
It is also possible to add null bytes directly using \u0000 in the server.properties file of a server.
Both of these issues result in invalid query responses and can even be used to intentionally inject fake values.

To prevent intentional injections, this pull request aims to reject responses that contain additional bytes after the end of the query response structure.

To parse query responses with an MOTD that contains null bytes, all null bytes within the MOTD field that are not followed by a valid known key are ignored. That one is a total hack, but I can't think of any better way of doing this.
It will also not eliminate the issue completely, as strings like `最numplayers` (a character that becomes a null byte followed by a valid key) would still cause an error.